### PR TITLE
bugfix: pin framework-arduinoespressif32

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,4 +16,6 @@ platform = espressif32
 framework = arduino
 board = esp32cam
 lib_deps = https://github.com/espressif/esp32-camera#7c5d8b229c4468c0413b89d7ef6224b13e5cdd8c
-platform_packages  = tool-mkspiffs @ ~1.200.0
+platform_packages  =
+    framework-arduinoespressif32 @ ~3.10006.0
+    tool-mkspiffs @ ~1.200.0


### PR DESCRIPTION
to the current release